### PR TITLE
chore: update umami tracking id in vitepress config

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -1,5 +1,4 @@
 import { defineConfig } from 'vitepress'
-import { env } from 'process'
 
 // https://vitepress.dev/reference/site-config
 export default defineConfig({
@@ -11,7 +10,7 @@ export default defineConfig({
       'script',
       {
         defer: 'true',
-        'data-website-id': env.UMAMI_WEBSITE_ID,
+        'data-website-id': '77d0dd59-9095-463b-a317-b49b373af92d',
         src: 'https://umami.zeeland.top/script.js'
       }
     ],


### PR DESCRIPTION
- Replace environment variable with hardcoded tracking ID
- Ensure consistent tracking across all environments

This change updates the Umami tracking ID in the VitePress configuration to a hardcoded value, ensuring that the correct tracking ID is used regardless of the environment.